### PR TITLE
Improve Inventory Tweaks perf with mods that reuse item ID with different metadata/damage values

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1704650211
+//version: 1704751096
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -786,7 +786,7 @@ dependencies {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.3.35')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.4.4')
     }
 
     java17PatchDependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}:forgePatches") {transitive = false}

--- a/src/main/java/invtweaks/InvTweaks.java
+++ b/src/main/java/invtweaks/InvTweaks.java
@@ -1014,9 +1014,12 @@ public class InvTweaks extends InvTweaksObfuscation {
     }
 
     private int getItemOrder(ItemStack itemStack) {
-        List<IItemTreeItem> items = cfgManager.getConfig().getTree()
-                .getItems(Item.itemRegistry.getNameForObject(itemStack.getItem()), itemStack.getItemDamage());
-        return (items != null && items.size() > 0) ? items.get(0).getOrder() : Integer.MAX_VALUE;
+        if (itemStack == null) {
+            return Integer.MAX_VALUE;
+        }
+
+        return cfgManager.getConfig().getTree()
+                .getItemOrder(Item.itemRegistry.getNameForObject(itemStack.getItem()), itemStack.getItemDamage());
     }
 
     private boolean isSortingShortcutDown() {

--- a/src/main/java/invtweaks/InvTweaksHandlerAutoRefill.java
+++ b/src/main/java/invtweaks/InvTweaksHandlerAutoRefill.java
@@ -71,8 +71,7 @@ public class InvTweaksHandlerAutoRefill extends InvTweaksObfuscation {
 
             // Find rules that match the slot
             for (IItemTreeItem item : items) {
-                if (!hasSubtypes || ((item.getDamage() == wantedDamage)
-                        || (item.getDamage() == InvTweaksConst.DAMAGE_WILDCARD))) {
+                if (!hasSubtypes || item.matchesDamage(wantedDamage)) {
                     // Since we search a matching item using rules,
                     // create a fake one that matches the exact item first
                     matchingRules.add(

--- a/src/main/java/invtweaks/InvTweaksItemTreeItem.java
+++ b/src/main/java/invtweaks/InvTweaksItemTreeItem.java
@@ -13,7 +13,8 @@ public class InvTweaksItemTreeItem implements IItemTreeItem {
 
     private String name;
     private String id;
-    private int damage;
+    private int damageMin;
+    private int damageMax;
     private int order;
 
     /**
@@ -25,7 +26,23 @@ public class InvTweaksItemTreeItem implements IItemTreeItem {
     public InvTweaksItemTreeItem(String name, String id, int damage, int order) {
         this.name = name;
         this.id = InvTweaksObfuscation.getNamespacedID(id);
-        this.damage = damage;
+        this.damageMin = damage;
+        this.damageMax = damage;
+        this.order = order;
+    }
+
+    /**
+     * @param name      The item name
+     * @param id        The item ID
+     * @param damageMin The lowest value of the item variant or InvTweaksConst.DAMAGE_WILDCARD
+     * @param damageMax The highest value of the item variant or InvTweaksConst.DAMAGE_WILDCARD
+     * @param order     The item order while sorting
+     */
+    public InvTweaksItemTreeItem(String name, String id, int damageMin, int damageMax, int order) {
+        this.name = name;
+        this.id = InvTweaksObfuscation.getNamespacedID(id);
+        this.damageMin = damageMin;
+        this.damageMax = damageMax;
         this.order = order;
     }
 
@@ -41,7 +58,17 @@ public class InvTweaksItemTreeItem implements IItemTreeItem {
 
     @Override
     public int getDamage() {
-        return damage;
+        // Not an ideal solution, but handles DAMAGE_WILDCARD cases nicely
+        return damageMin;
+    }
+
+    @Override
+    public boolean matchesDamage(int damage) {
+        if (damage == InvTweaksConst.DAMAGE_WILDCARD || this.damageMin == InvTweaksConst.DAMAGE_WILDCARD
+                || this.damageMax == InvTweaksConst.DAMAGE_WILDCARD) {
+            return true;
+        }
+        return damage >= this.damageMin && damage <= this.damageMax;
     }
 
     @Override
@@ -58,8 +85,8 @@ public class InvTweaksItemTreeItem implements IItemTreeItem {
             return false;
         }
         IItemTreeItem item = (IItemTreeItem) o;
-        return ObjectUtils.equals(id, item.getId())
-                && (damage == InvTweaksConst.DAMAGE_WILDCARD || damage == item.getDamage());
+        return ObjectUtils.equals(id, item.getId()) && (damageMin == InvTweaksConst.DAMAGE_WILDCARD
+                || (damageMin <= item.getDamage() && damageMax >= item.getDamage()));
     }
 
     public String toString() {

--- a/src/main/java/invtweaks/InvTweaksItemTreeLoader.java
+++ b/src/main/java/invtweaks/InvTweaksItemTreeLoader.java
@@ -121,15 +121,14 @@ public class InvTweaksItemTreeLoader extends DefaultHandler {
                 String id = attributes.getValue(ATTR_ID);
                 int rangeDMin = Integer.parseInt(rangeDMinAttr);
                 int rangeDMax = Integer.parseInt(attributes.getValue(ATTR_RANGE_DMAX));
-                for (int damage = rangeDMin; damage <= rangeDMax; damage++) {
-                    tree.addItem(
-                            name,
-                            new InvTweaksItemTreeItem(
-                                    (name + id + "-" + damage).toLowerCase(),
-                                    id,
-                                    damage,
-                                    itemOrder++));
-                }
+                tree.addItem(
+                        name,
+                        new InvTweaksItemTreeItem(
+                                (name + id + "-" + rangeDMin + "-" + rangeDMax).toLowerCase(),
+                                id,
+                                rangeDMin,
+                                rangeDMax,
+                                itemOrder++));
             }
 
             categoryStack.add(name);

--- a/src/main/java/invtweaks/api/IItemTree.java
+++ b/src/main/java/invtweaks/api/IItemTree.java
@@ -37,6 +37,8 @@ public interface IItemTree {
 
     List<IItemTreeItem> getItems(String name);
 
+    int getItemOrder(String id, int damage);
+
     IItemTreeItem getRandomItem(Random r);
 
     boolean containsItem(String name);

--- a/src/main/java/invtweaks/api/IItemTreeItem.java
+++ b/src/main/java/invtweaks/api/IItemTreeItem.java
@@ -21,5 +21,7 @@ public interface IItemTreeItem extends Comparable<IItemTreeItem> {
 
     int getDamage();
 
+    boolean matchesDamage(int damage);
+
     int getOrder();
 }


### PR DESCRIPTION
This improves performance of Inventory Tweaks by clumping together damage values into a single entry instead of duplicating entries, and optimizes damage-based sorting.

Primarily this makes it lag less when using Inventory Tweaks to sort AE2 terminals.


My test tree (when I started noticing the low perf) if anyone else wants to try with it to compare before/after:
[InvTweaksTree.txt](https://github.com/GTNewHorizons/inventory-tweaks/files/13896392/InvTweaksTree.txt)
