### PR TITLE
Make auto-refill log use DEBUG level instead of INFO

### DIFF
--- a/src/main/java/invtweaks/InvTweaksHandlerAutoRefill.java
+++ b/src/main/java/invtweaks/InvTweaksHandlerAutoRefill.java
@@ -149,7 +149,7 @@ public class InvTweaksHandlerAutoRefill extends InvTweaksObfuscation {
 
         if (replacementStack != null || (refillBeforeBreak && container.getSlot(slot).getStack() != null)) {
 
-            log.info("Automatic stack replacement.");
+            log.debug("Automatic stack replacement.");
 
             /*
              * This allows to have a short feedback that the stack/tool is empty/broken.


### PR DESCRIPTION
This makes the log that occurs when an item is auto-refilled (auto-replaced?) in the hotbar use DEBUG instead of INFO.

Currently, when an item is replaced many times, the log is filled up with "Automatic stack replacement". This could be caused by using many stacks of one type of block, or using lots of filled buckets (which are auto-replaced when emptied). By changing this log call to use DEBUG level instead of INFO, the log is not spammed anymore.

There are other logs in the inventory sorting part of this mod, but maybe sorting doesn't happen as often, so I left them alone. I can figure out a solution for those too, if needed.